### PR TITLE
fix(ci-cd): CI/CD 파이프라인 개선 및 docker-compose 분리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,18 +2,16 @@
 # cp .env.example .env
 
 # Database
-MYSQL_HOST=localhost
-MYSQL_PORT=3307
-MYSQL_DATABASE=handsup_dev
 MYSQL_USER=root
 MYSQL_ROOT_PASSWORD=
+MYSQL_PORT=3307
+MYSQL_DATABASE=handsup_dev
 
 # Redis
-REDIS_HOST=localhost
 REDIS_PORT=6380
 REDIS_HOST_PASSWORD=
 
-# Kafka (로컬: localhost:29092, 운영: EC2 주소)
+# Kafka
 KAFKA_BOOTSTRAP_SERVERS=localhost:29092
 
 # AWS S3
@@ -30,7 +28,3 @@ SLACK_WEBHOOK_URL=
 
 # OpenAI
 OPENAI_API_KEY=
-
-# Docker Hub (docker-compose 배포 시 사용)
-DOCKERHUB_USERNAME=
-DOCKERHUB_APP_NAME=

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Generate .env file
         run: echo "${{ secrets.ENV_CONTENT }}" > .env
 
-      # 10. EC2 서버로 docker-compose.yml, .env 파일 복사
+      # 10. EC2 서버로 docker-compose.prod.yml, .env 파일 복사
       - name: Copy files to EC2 for docker-compose
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -73,7 +73,7 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
           port: ${{ secrets.EC2_PORT }}
-          source: "docker-compose.yml,.env"
+          source: "docker-compose.prod.yml,.env"
           target: "~/compose/"
 
       # 11. EC2에서 컨테이너 배포 및 실행
@@ -87,7 +87,7 @@ jobs:
           script: |
             mkdir -p ~/compose
             cd ~/compose
-            docker-compose down
+            docker-compose -f docker-compose.prod.yml down
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }}
-            docker-compose up -d
+            docker-compose -f docker-compose.prod.yml up -d
             docker system prune -f

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: 📌 CD Backend
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
 
 permissions:
   contents: read
@@ -13,11 +13,11 @@ jobs:
     steps:
       # 1. 리포지토리 체크아웃
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # 2. 자바 버전 설정
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -28,14 +28,14 @@ jobs:
           mkdir -p ./core/src/main/resources/firebase
           echo "${{ secrets.FIREBASE_ACCOUNT }}" | base64 -d > ./core/src/main/resources/firebase/firebase_account.json
 
-      # 5. gradlew 실행 권한 부여
+      # 4. gradlew 실행 권한 부여
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
         shell: bash
 
-      # 6. gradle 빌드 캐시 적용
+      # 5. gradle 빌드 캐시 적용
       - name: Gradle Caching
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -44,41 +44,41 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # 7. Gradle 빌드 (테스트 제외)
+      # 6. Gradle 빌드 (테스트 제외)
       - name: Build with Gradle
         run: ./gradlew build -x test
 
-      # 8. Docker Hub 로그인
+      # 7. Docker Hub 로그인
       - name: Docker Hub Login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # 9. Docker 이미지 빌드 및 푸시
+      # 8. Docker 이미지 빌드 및 푸시
       - name: docker image build and push
         run: |
           docker build -f Dockerfile -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }} .
           docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }}
 
-      # 10. .env 파일 생성 (.gitignore 처리된 파일)
+      # 9. .env 파일 생성 (.gitignore 처리된 파일)
       - name: Generate .env file
         run: echo "${{ secrets.ENV_CONTENT }}" > .env
 
-      # 11. EC2 서버로 Dockerfile, docker-compose.yml, .env 파일 복사
+      # 10. EC2 서버로 docker-compose.yml, .env 파일 복사
       - name: Copy files to EC2 for docker-compose
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
           port: ${{ secrets.EC2_PORT }}
-          source: "Dockerfile,docker-compose.yml,.env"
+          source: "docker-compose.yml,.env"
           target: "~/compose/"
 
-      # 12. EC2에서 컨테이너 배포 및 실행
+      # 11. EC2에서 컨테이너 배포 및 실행
       - name: pull image and run container
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
@@ -88,6 +88,6 @@ jobs:
             mkdir -p ~/compose
             cd ~/compose
             docker-compose down
-            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }} 
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }}
             docker-compose up -d
             docker system prune -f

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: ⚙️ CI Backend
 
 on:
-  #  push:
-  #    branches: [ "*" ]
   pull_request:
     branches: [ "main", "dev" ]
 
@@ -22,8 +20,6 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
           MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
-          MYSQL_USER: ${{ secrets.MYSQL_USER }}
-          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
       redis:
         image: redis:latest
         ports:
@@ -46,17 +42,11 @@ jobs:
       TZ: 'Asia/Seoul'
       MYSQL_HOST: localhost
       MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
-      MYSQL_USER: ${{ secrets.MYSQL_USER }}
-      MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
       MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
-      #      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #      AWS_REGION: ${{ secrets.AWS_REGION }}
-      #      AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
     steps:
       # 1. 체크아웃
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # 2. 시간 설정
       - name: Check the timezone
@@ -64,7 +54,7 @@ jobs:
 
       # 3. 자바 버전 설정
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -73,7 +63,7 @@ jobs:
       - name: Generate firebase_account.json
         run: |
           mkdir -p ./core/src/main/resources/firebase
-          echo "${{ secrets.FIREBASE_ACCOUNT }}" | base64 -d > ./core/src/main/resources/firebase/firebase_account.json          
+          echo "${{ secrets.FIREBASE_ACCOUNT }}" | base64 -d > ./core/src/main/resources/firebase/firebase_account.json
           mkdir -p ./core/src/test/resources/firebase
           echo "${{ secrets.FIREBASE_ACCOUNT }}" | base64 -d > ./core/src/test/resources/firebase/firebase_account.json
           mkdir -p ./api/src/test/resources/firebase
@@ -113,13 +103,6 @@ jobs:
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.html'
-
-      - name: Checkout source code
-        uses: actions/checkout@v3
-
-      #      # 10. JaCoCo 리포트 생성
-      #      - name: Generate JaCoCo Report
-      #        run: ./gradlew test jacocoTestReport
 
       # 10. Codecov 업로드
       - name: Upload coverage to Codecov

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ out/
 
 /core/src/main/generated/
 .env
+.env.prod
 
 # FCM
 /core/src/main/resources/firebase/firebase_account.json

--- a/core/src/test/java/dev/handsup/bidding/repository/BiddingConcurrencyTest.java
+++ b/core/src/test/java/dev/handsup/bidding/repository/BiddingConcurrencyTest.java
@@ -30,6 +30,7 @@ import dev.handsup.support.TestContainerSupport;
 import dev.handsup.user.domain.User;
 import dev.handsup.user.repository.UserRepository;
 
+@Disabled("동시성 테스트 미완성")
 @DisplayName("[BiddingConcurrency 테스트]")
 @Slf4j
 @SpringBootTest
@@ -62,7 +63,6 @@ class BiddingConcurrencyTest extends TestContainerSupport {
         user = userRepository.save(UserFixture.user1());
     }
 
-    @Disabled
     @DisplayName("[동시에 500개 요청 시, 입찰 금액이 모두 같다면 하나의 입찰만 저장된다.]")
     @Test
     void concurrency_test() throws InterruptedException {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,61 @@
+services:
+  redis:
+    image: redis:latest
+    container_name: hands-up-redis
+    ports:
+      - "6380:6379"
+    volumes:
+      - redis_data:/data
+    restart: always
+    command: [ "redis-server", "--requirepass", "${REDIS_HOST_PASSWORD}" ]
+
+  mysql:
+    image: mysql:8.0
+    container_name: hands-up-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+    ports:
+      - "3307:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    restart: always
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+  app:
+    image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_NAME}:latest
+    volumes:
+      - ./gc-logs:/logs
+    container_name: hands-up-app
+    ports:
+      - "8080:8080"
+    environment:
+      TZ: Asia/Seoul
+      SPRING_PROFILES_ACTIVE: prod
+      SPRING_DATASOURCE_URL: jdbc:mysql://hands-up-mysql:3306/${MYSQL_DATABASE}
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      SPRING_DATA_REDIS_HOST: hands-up-redis
+      SPRING_DATA_REDIS_PORT: 6379
+      SPRING_DATA_REDIS_PASSWORD: ${REDIS_HOST_PASSWORD}
+      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS}
+      CLOUD_AWS_CREDENTIALS_ACCESS_KEY: ${CLOUD_AWS_CREDENTIALS_ACCESS_KEY}
+      CLOUD_AWS_CREDENTIALS_SECRET_KEY: ${CLOUD_AWS_CREDENTIALS_SECRET_KEY}
+      CLOUD_AWS_REGION_STATIC: ${CLOUD_AWS_REGION_STATIC}
+      CLOUD_AWS_S3_BUCKET: ${CLOUD_AWS_S3_BUCKET}
+      JWT_SECRET: ${JWT_SECRET}
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+    restart: always
+    depends_on:
+      - redis
+      - mysql
+
+volumes:
+  redis_data:
+  mysql_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,39 +50,6 @@ services:
       - kafka_data:/var/lib/kafka/data
     restart: always
 
-  app:
-    image: ${DOCKERHUB_USERNAME}/${DOCKERHUB_APP_NAME}:latest
-    #    build:
-    #      context: .
-    #      dockerfile: Dockerfile
-    volumes:
-      - ./gc-logs:/logs
-    container_name: hands-up-app
-    ports:
-      - "8080:8080"
-    environment:
-      TZ: Asia/Seoul
-      SPRING_PROFILES_ACTIVE: prod
-      SPRING_DATASOURCE_URL: jdbc:mysql://hands-up-mysql:3306/${MYSQL_DATABASE}
-      SPRING_DATASOURCE_USERNAME: root
-      SPRING_DATASOURCE_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      SPRING_DATA_REDIS_HOST: hands-up-redis
-      SPRING_DATA_REDIS_PORT: 6379
-      SPRING_DATA_REDIS_PASSWORD: ${REDIS_HOST_PASSWORD}
-      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS}
-      CLOUD_AWS_CREDENTIALS_ACCESS_KEY: ${CLOUD_AWS_CREDENTIALS_ACCESS_KEY}
-      CLOUD_AWS_CREDENTIALS_SECRET_KEY: ${CLOUD_AWS_CREDENTIALS_SECRET_KEY}
-      CLOUD_AWS_REGION_STATIC: ${CLOUD_AWS_REGION_STATIC}
-      CLOUD_AWS_S3_BUCKET: ${CLOUD_AWS_S3_BUCKET}
-      JWT_SECRET: ${JWT_SECRET}
-      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
-      OPENAI_API_KEY: ${OPENAI_API_KEY}
-    restart: always
-    depends_on:
-      - redis
-      - mysql
-      - kafka
-
 volumes:
   redis_data:
   mysql_data:


### PR DESCRIPTION
## Summary
- CI/CD 워크플로우 Actions 버전 업그레이드 (v3 → v4)
- docker-compose를 로컬(`docker-compose.yml`)과 운영(`docker-compose.prod.yml`)으로 분리
- CI에서 불필요한 secrets 제거 (`MYSQL_USER`, `MYSQL_PASSWORD`)
- CD 트리거를 `main` 브랜치만으로 한정
- `.env.example` 로컬 개발용에 맞게 정리

## Test plan
- [ ] CI: 이 PR에서 빌드 및 테스트 통과 확인
- [ ] CD: GitHub Secrets 등록 후 main 머지 시 배포 정상 동작 확인