### PR TITLE
chore: main 운영 배포 작업 dev 브랜치 동기화

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       # 1. 리포지토리 체크아웃
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # 2. 자바 버전 설정
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -35,7 +35,7 @@ jobs:
 
       # 5. gradle 빌드 캐시 적용
       - name: Gradle Caching
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -50,7 +50,7 @@ jobs:
 
       # 7. Docker Hub 로그인
       - name: Docker Hub Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       # 1. 체크아웃
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # 2. 시간 설정
       - name: Check the timezone
@@ -54,7 +54,7 @@ jobs:
 
       # 3. 자바 버전 설정
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -77,7 +77,7 @@ jobs:
       # 6. 빌드 시 의존성 캐싱
       - name: Caching gradle
         if: always()
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -99,7 +99,7 @@ jobs:
 
       # 9. 테스트 실패시 코드 라인에 대한 체크 추가
       - name: If test fail, add check comment on failed code line
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@v5
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.html'

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ out/
 /core/src/test/resources/firebase/firebase_account.json
 /api/src/test/resources/firebase/firebase_account.json
 /event/src/test/resources/firebase/firebase_account.json
+
+# 포트폴리오 어필 포인트 초안 (공개 저장소 노출 방지, 로컬 전용)
+docs/PORTFOLIO_HIGHLIGHTS.md
+
+# JVM GC 로그 (런타임 산출물)
+gc-logs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Test Commands
+
+```bash
+# Build
+./gradlew build                    # Build with tests
+./gradlew build -x test            # Build without tests
+
+# Test
+./gradlew test                     # Run all tests
+./gradlew :core:test               # Run core module tests only
+./gradlew :api:test                # Run api module tests only
+./gradlew test --tests '*ServiceTest'  # Run tests matching pattern
+
+# Coverage
+./gradlew jacocoTestReport         # Generate coverage report (HTML in build/reports/jacoco)
+
+# Run
+./gradlew :api:bootRun             # Start the application
+```
+
+## Project Architecture
+
+**Multi-module Gradle project** (Java 17, Spring Boot 3.2.0):
+
+- **api** - REST controllers, request/response DTOs, WebSocket endpoints. Entry point: `HandsUpApplication.java`
+- **core** - Business logic, domain entities, services, repositories. Contains QueryDSL configuration
+- **event** - Kafka producers/consumers for async event processing
+- **common** - Shared utilities (java-library, no Spring Boot)
+
+Module dependencies: `api → core, event` | `event → core`
+
+## Domain Model
+
+Peer-to-peer auction marketplace with these core entities:
+
+- **Auction** (aggregate root) - Contains Product, status lifecycle (BIDDING → TRADING → COMPLETED)
+- **Bidding** - User bids with trading status (WAITING → PREPARING → PROGRESSING → COMPLETED/CANCELED)
+- **User** - Participants with reputation score (0-200)
+- **ChatRoom/ChatMessage** - Seller-bidder communication
+- **Review** - Post-transaction ratings affecting user score
+
+Domain packages follow: `domain/`, `service/`, `repository/`, `dto/`, `exception/`
+
+## Key Patterns
+
+- **Layered + DDD**: Rich domain entities with validation in constructors
+- **Event-Driven**: Kafka for async processing (BiddingEventProducer/Listener)
+- **Query Repositories**: QueryDSL for complex queries (e.g., `AuctionQueryRepository`)
+- **Schedulers**: `AuctionScheduler`, `BiddingScheduler` for status transitions
+- **Caching**: Caffeine (local) + Redis (distributed)
+
+## Testing
+
+Test base classes in `core/src/test/java/dev/handsup/common/support/`:
+
+- `DataJpaTestSupport` - Repository tests with TestContainers (MySQL + Redis)
+- `ApiTestSupport` - Controller integration tests with MockMvc
+- `ApiTestKafkaSupport` - Tests requiring embedded Kafka
+
+Fixtures in `core/src/testFixtures/java/dev/handsup/fixture/`:
+- `AuctionFixture`, `UserFixture`, `BiddingFixture`, etc. - Static factory methods for test data
+
+## External Services
+
+- MySQL (primary DB), Redis (cache/locking), Kafka (events)
+- AWS S3 (images), Firebase FCM (push notifications), OpenAI API
+- Elasticsearch (search - in development on feat/es-auction-search branch)
+
+## 작업 기록
+
+### 2026-07-06 - EC2 App ↔ 외부 EC2 Kafka 연동 문제 해결 및 운영 설정 마무리
+
+**배경**
+- App은 EC2 A(main push → `cd.yml`)에, Kafka는 별도 EC2 B(dev push → `cd-dev.yml`, `docker-compose.dev.yml`)에 배포되는 분리 구조.
+- 배포된 App이 외부 Kafka 브로커에 붙지 못하고 `Bootstrap broker ... disconnected` 경고가 반복되던 것을 추적/해결.
+
+**해결한 근본 원인 (3가지)**
+- **포트 불일치**: App의 `KAFKA_BOOTSTRAP_SERVERS`가 `:9092`를 가리켰으나, Kafka의 외부 접속 포트는 `29092`(컨테이너 EXTERNAL 리스너 `9094` → 호스트 `29092`). 내부 `9092`는 호스트에 퍼블리시되지 않아 도달 불가. → App 시크릿을 `172.31.38.179:29092`로 수정.
+- **advertised host**: Kafka의 `KAFKA_ADVERTISED_HOST`를 퍼블릭 IP로 두면 EC2 재시작 시 IP가 바뀌어 광고 주소가 낡음. 두 EC2가 같은 VPC(`172.31.x`)이므로 **프라이빗 IP `172.31.38.179`로 통일** (재부팅에도 고정, 인터넷 미경유, 브로커 미노출). 확인 결과 이미 프라이빗으로 설정돼 있었음.
+- **보안그룹**: Kafka EC2 SG에 `29092` 인바운드 추가, Source를 App EC2 SG(`sg-0f371a0e8279f12fb`) 또는 VPC CIDR로 제한. (기존 CIDR 규칙은 SG 참조로 in-place 변경 불가 → 삭제 후 재생성 필요)
+
+**결과 (검증됨)**
+- App 로그에서 `disconnected` 경고 소멸. 대신 `UNKNOWN_TOPIC_OR_PARTITION`(bidding-events.dlt-retry/dlt-dlt)만 남음 = **브로커 연결 성공**, 새 클러스터라 토픽 미생성 상태(auto-create로 첫 메시지 시 생성). 네트워크/포트/advertised 이슈 모두 해결.
+
+**변경 파일 (미커밋)**
+- `api/src/main/resources/application-prod.yml` - `ddl-auto: update → validate`. 첫 배포용 임시 `update`(커밋 `be7bc6f`)를 앱 안정화 후 되돌림. 운영에서 update 상시 유지는 의도치 않은 스키마 변경 위험.
+- `.gitignore` - `docs/PORTFOLIO_HIGHLIGHTS.md` 로컬 전용 무시 추가.
+- `docs/PORTFOLIO_HIGHLIGHTS.md` - (gitignore됨) 포트폴리오 기록 파일 신규.
+
+**결정 사항**
+- Kafka 연동은 **프라이빗 IP 기준**으로 통일. App/Kafka 양쪽 IP·포트 정합성이 핵심(bootstrap 대상과 advertised host가 같은 도달 가능 주소여야 함).
+- App EC2에 EIP 미부착 시 재시작으로 퍼블릭 IP가 바뀌면 `EC2_HOST` 시크릿과 불일치 → CD의 SCP가 `i/o timeout`. 근본 해결책으로 **EIP 부착 권장**(미적용).
+- GitHub Secret(`ENV_CONTENT`/`ENV_DEV_CONTENT`) 값은 CD 워크플로에서만 EC2로 주입됨 → 시크릿 변경은 **반드시 push(또는 워크플로 재실행)** 로 반영. EC2에서 `compose up`만 하면 옛 `.env`를 읽어 미반영.
+
+**다음 작업**
+- 미커밋 변경 커밋 필요: `application-prod.yml`(ddl-auto validate 복귀), `.gitignore`. 제안 메시지: `fix(prod): 앱 안정화 완료로 ddl-auto를 validate로 복귀`.
+- `validate` 적용은 **main push로 CD 트리거 시** 발효. 배포 후 `docker logs hands-up-app`에서 `Schema-validation` 오류 없이 기동하는지 확인 필수(불일치 시 기동 거부).
+- Kafka end-to-end 검증: 실제 입찰 발생 → kafka-ui(`http://<KafkaIP>:8080`)에서 `bidding-events` 토픽 메시지 증가 확인.
+- CLUSTER_ID 백업: `docker exec hands-up-kafka cat /var/lib/kafka/data/meta.properties`의 `cluster.id`를 안전한 곳에 보관하고 `ENV_DEV_CONTENT` 시크릿 값과 일치 확인(불일치 시 재배포 실패, 새 발급은 볼륨 초기화 필요).
+- dev ↔ main 브랜치 동기화 필요(main에 직접 커밋한 CI/CD 작업들이 dev에 미반영).
+- `gc-logs/` 미추적 디렉터리 존재 - gitignore 여부 검토 필요.

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -2,7 +2,7 @@ spring:
   jpa:
     show-sql: false
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: false

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -6,6 +6,13 @@ spring:
     properties:
       hibernate:
         format_sql: false
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+
+event:
+  kafka:
+    enabled: false
 
 logging:
   level:

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -6,13 +6,6 @@ spring:
     properties:
       hibernate:
         format_sql: false
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
-
-event:
-  kafka:
-    enabled: false
 
 logging:
   level:

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -2,7 +2,7 @@ spring:
   jpa:
     show-sql: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: false

--- a/docs/bidding-concurrency-fix-plan.md
+++ b/docs/bidding-concurrency-fix-plan.md
@@ -1,0 +1,85 @@
+# Plan: 입찰 동시성 제어 버그 수정
+
+## 문제 분석
+
+`BiddingConcurrencyTest.concurrency_test()` 테스트가 실패하여 `@Disabled` 처리됨.
+- 100개 스레드가 동일 가격으로 동시 입찰 시, 1개만 저장되어야 하지만 여러 개가 저장됨
+
+### 근본 원인: AOP Aspect 순서 문제
+
+`@Transactional`과 `@DistributeLock` 간의 실행 순서가 정의되지 않아:
+1. 여러 스레드가 트랜잭션을 먼저 시작 (DB 스냅샷 읽음)
+2. 모든 스레드가 `maxBiddingPrice = NULL` 읽음 (stale data)
+3. 락 획득 후에도 이미 읽은 데이터 사용 → 여러 입찰 저장됨
+
+### 추가 문제: leaseTime < waitTime
+- `waitTime=5s`, `leaseTime=3s` → 트랜잭션이 3초 넘으면 락 자동 해제
+
+## 수정 계획
+
+### 1. DistributeLockAop에 @Order 추가
+**파일**: `core/src/main/java/dev/handsup/common/redisson/DistributeLockAop.java`
+
+```java
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE)  // 추가
+public class DistributeLockAop {
+```
+
+→ 락이 트랜잭션보다 먼저 실행되도록 보장
+
+### 2. BiddingService.registerBidding()에서 @Transactional 제거
+**파일**: `core/src/main/java/dev/handsup/bidding/service/BiddingService.java`
+
+```java
+// 변경 전
+@Transactional
+@DistributeLock(key = "'auction_' + #auctionId")
+public BiddingResponse registerBidding(...) {
+
+// 변경 후
+@DistributeLock(key = "'auction_' + #auctionId")
+public BiddingResponse registerBidding(...) {
+```
+
+→ `AopForTransaction.proceed()`의 `REQUIRES_NEW`가 트랜잭션 관리
+
+### 3. DistributeLock 기본 leaseTime 증가
+**파일**: `core/src/main/java/dev/handsup/common/redisson/DistributeLock.java`
+
+```java
+// 변경 전
+long leaseTime() default 3L;
+
+// 변경 후
+long leaseTime() default 10L;
+```
+
+### 4. 테스트 활성화
+**파일**: `core/src/test/java/dev/handsup/bidding/repository/BiddingConcurrencyTest.java`
+
+`@Disabled` 어노테이션 제거
+
+## 수정 후 예상 동작
+
+```
+Thread A: [락 획득] → [TX 시작] → [maxPrice=NULL 읽음] → [저장] → [커밋] → [락 해제]
+Thread B: [락 대기...] → [락 획득] → [TX 시작] → [maxPrice=10000 읽음] → [검증 실패!] → [락 해제]
+```
+
+→ 1개의 입찰만 저장됨
+
+## 검증 방법
+
+```bash
+./gradlew :core:test --tests '*BiddingConcurrencyTest*'
+```
+
+- `biddingRepository.findAll().hasSize(1)` 통과 확인
+- 로그에서 `unlock skipped: lock not held by current thread` 경고 없음 확인


### PR DESCRIPTION
## 요약
main에 직접 커밋된 CI/CD·운영 배포 관련 변경사항을 dev에 동기화합니다. EC2 배포(CD)가 main push 트리거라 운영 안정화 작업들이 main에서 먼저 진행되었습니다.

## 변경사항
- CI/CD 파이프라인 정리 (actions 버전 업그레이드, docker-compose 로컬/운영 분리)
- 테스트: `BiddingConcurrencyTest` `@Disabled`를 클래스 레벨로 이동 (CI 컨텍스트 로드 실패 방지)
- Codecov JaCoCo 리포트 경로 수정 및 PR 커버리지 코멘트 설정
- GitHub Actions Node.js 24 호환 버전 업그레이드
- `application-prod.yml`: 첫 배포를 위해 `ddl-auto: update`로 변경했다가, 앱 안정화 확인 후 `validate`로 복귀 (중간에 Kafka auto-configuration 비활성화 시도했으나 근본 원인(ENV_CONTENT 미설정) 해결로 대체 후 revert)

## 검증
- CI/CD 파이프라인 실제 트리거하여 EC2 배포 완료, 앱 정상 기동 확인
- 외부 EC2 Kafka 브로커 연동 문제(포트 불일치, advertised host, 보안그룹) 해결 후 App 로그에서 disconnect 경고 소멸 확인
- `ddl-auto: validate` 복귀 후 재배포하여 Schema-validation 통과 확인 예정

## 관련 이슈
- 없음